### PR TITLE
Fix incorrect type for DrawText arguments

### DIFF
--- a/genx/genx/plugins/add_ons/help_modules/custom_dialog.py
+++ b/genx/genx/plugins/add_ons/help_modules/custom_dialog.py
@@ -1062,7 +1062,7 @@ class FitSelectorCombo(wx.ComboCtrl):
         font.SetWeight(wx.FONTWEIGHT_BOLD)
         dc.SetFont(font)
         tw, th=dc.GetTextExtent(label)
-        dc.DrawText(label, (bw-tw)/2, (bh-th)/2)
+        dc.DrawText(label, (bw-tw)//2, (bh-th)//2)
         del dc
         # now apply a mask using the bgcolor
         bmp.SetMaskColour(bgcolor)
@@ -1146,7 +1146,7 @@ class ParameterExpressionCombo(wx.ComboCtrl):
         font.SetWeight(wx.FONTWEIGHT_BOLD)
         dc.SetFont(font)
         tw, th=dc.GetTextExtent(label)
-        dc.DrawText(label, (bw-tw)/2, (bh-th)/2)
+        dc.DrawText(label, (bw-tw)//2, (bh-th)//2)
         del dc
         # now apply a mask using the bgcolor
         bmp.SetMaskColour(bgcolor)


### PR DESCRIPTION
DrawText arguments are supposed to be integer, not floating point (see https://wxpython.org/Phoenix/docs/html/wx.DC.html#wx.DC.DrawText).

Fixes a bug where the instrument editor in advanced reflectivity would not work.