### PR TITLE
Manage changes in keywords in newer urllib3 versions

### DIFF
--- a/genx/genx/gui/online_update.py
+++ b/genx/genx/gui/online_update.py
@@ -21,11 +21,19 @@ from ..version import __version__ as GENX_VERSION
 GITHUB_URL="https://api.github.com/repos/aglavic/genx/releases/latest"
 GITHUB_TAGS="https://api.github.com/repos/aglavic/genx/tags"
 
+
+def _get_Retry_kw():
+    if hasattr(Retry.DEFAULT, "allowed_methods"):
+        return {"allowed_methods": ["HEAD", "GET", "OPTIONS"]}
+    return {"method_whitelist": ["HEAD", "GET", "OPTIONS"]}
+
+
 retry_strategy = Retry(
     total=3,
     status_forcelist=[429, 500, 502, 503, 504],
-    method_whitelist=["HEAD", "GET", "OPTIONS"]
+    **_get_Retry_kw()
 )
+
 
 def check_version():
     adapter = HTTPAdapter(max_retries=retry_strategy)


### PR DESCRIPTION
The module urllib3 has changed some keywords, apparently when going from 1.25 to 1.26 Since genx does not require a specific version of this module (it is inherited from requests), this breaking change raises errors on users with newer versions of this library. This fix uses the approach suggested in urllib3's issue [2057](https://github.com/urllib3/urllib3/issues/2057).