### PR TITLE
Add layer param

### DIFF
--- a/genx/genx/gui/parametergrid.py
+++ b/genx/genx/gui/parametergrid.py
@@ -1373,7 +1373,7 @@ class ParameterGrid(wx.Panel, Configurable):
         self.Bind(wx.EVT_MENU, self.OnPopUpItemSelected, item)
 
         # Add item for automatic adding of all relevant instrument, layer and sub parameters
-        item = self.pmenu.Append(-1, "Add Layer Items")
+        item = self.pmenu.Append(-1, "Common pars")
         self.Bind(wx.EVT_MENU, self.OnPopUpItemSelected, item)
 
         self.PopupMenu(self.pmenu, pos)
@@ -1416,7 +1416,7 @@ class ParameterGrid(wx.Panel, Configurable):
                 self.grid.EnableCellEditControl()
             return
     
-        if item.GetItemLabel() == "Add Layer Items":
+        if item.GetItemLabel() == "Common pars":
             # Added by Kibbi 15/04/25
             # Easy way to add relevant instrument parameters and 
             # most commonly used layer parameters with a single click

--- a/genx/genx/gui/parametergrid.py
+++ b/genx/genx/gui/parametergrid.py
@@ -1436,11 +1436,12 @@ class ParameterGrid(wx.Panel, Configurable):
             self.table.InsertRow(i)
             
             # Layer items to add
-            layItemsToAdd = ['setDens','setD','setSigma']
-            
-            for par in self.par_dict['Layer'].keys():
+            layerItemsToAdd = ['setDens','setD','setSigma']
+            # Reversing layers so 'sub' is on top and we go up the sample
+            layers = list(reversed(self.par_dict['Layer'].keys()))
+            for par in layers:
                 if par != 'Amb':
-                    for it in layItemsToAdd:
+                    for it in layerItemsToAdd:
                         # add three lines and one empty
                         try:
                             self.fillLine(par, it,i)


### PR DESCRIPTION
Added a submenu item on the parameter grid. When pushed after the parameters have been simulated  the grid is populated with the most commonly used parameters for _instr_ and  _Layer_ of the sample.

For _instr_  the parameters added are setI0, setIbkg, setBeamw and setRes and for each _Layer_ that is setD, setDens and setSigma.

GIF attached to see functionality. This saves a lot of time when creating new models as I find the grid operations most tedious. 

![kibbi_genx](https://github.com/user-attachments/assets/d6eb998e-1c6c-40bc-91a5-a72c460955e4)
